### PR TITLE
Add a library that matches the package name

### DIFF
--- a/lisp/esn.el
+++ b/lisp/esn.el
@@ -1,0 +1,47 @@
+;;; esn.el --- Emacs Speaks NONMEM
+;;
+;; Filename: esn.el
+;; Description: Main entry point for Emacs Speaks NONMEM
+;; Author: Matthew L. Fidler
+;; Maintainer: Matthew Fidler
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; This package implements an interface to NONMEM.
+;;
+;; NONMEM is ICON's NONlinear Mixed Effects Modelling tool, the industry
+;; standard for population PK/PD analysis
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change log:
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 3, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program; see the file COPYING.  If not, write to
+;; the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+;; Floor, Boston, MA 02110-1301, USA.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+(require 'esn-start)
+(provide 'esn)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; esn.el ends here


### PR DESCRIPTION
Every package should feature a library that matches the name of the package.  Various tools use that file to extract metadata.

There are only a dozen packages for which this isn't the case, so I have hope that we can get this to zero.  See https://emacsmirror.net/stats/kludges.html#org04b0b94.